### PR TITLE
Change order of files in `concat_sourcemap` task

### DIFF
--- a/config/plugins/less.coffee
+++ b/config/plugins/less.coffee
@@ -23,7 +23,7 @@ module.exports = (lineman) ->
 
     concat_sourcemap:
       css:
-        src: ["<%= files.less.generated %>"].concat(app.concat_sourcemap.css.src)
+        src: app.concat_sourcemap.css.src.concat(["<%= files.less.generated %>"])
 
     watch:
       less:


### PR DESCRIPTION
I could be wrong about this, but without this change, my application's CSS files were concatenated before my vendor files. Should it not be the other way around?
